### PR TITLE
(Support Android Q) add clearTextTrafficPermitted property

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,14 +6,17 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+
+
     <application
-        android:name=".core.App"
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+            android:name=".core.App"
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:networkSecurityConfig="@xml/network_security_configuration"
+            android:theme="@style/AppTheme">
 
         <activity android:name=".ui.home.MainActivity">
         <intent-filter>

--- a/app/src/main/java/com/architecture/clean/core/Config.kt
+++ b/app/src/main/java/com/architecture/clean/core/Config.kt
@@ -1,5 +1,5 @@
 package com.architecture.clean.core
 
 object Config {
-    var HOST = "http://www.recipepuppy.com/"
+    var HOST = "http://www.recipepuppy.com"
 }

--- a/app/src/main/res/xml/network_security_configuration.xml
+++ b/app/src/main/res/xml/network_security_configuration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">recipepuppy.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
can't make requests to http links on android Q otherwise, and api doesn't support https

also removing unnecessary final slash in HOST baseUrl 